### PR TITLE
Fix Notice when call constructor

### DIFF
--- a/src/MobizonApi.php
+++ b/src/MobizonApi.php
@@ -118,14 +118,15 @@ class MobizonApi
      * @throws Mobizon_Error
      * @throws Mobizon_OpenSSL_Required
      */
-    public function __construct($params = array())
+    public function __construct()
     {
         if (!function_exists('curl_init')) {
             throw new Mobizon_Curl_Required('The curl extension is required but not currently enabled.');
         }
         $args = func_get_args();
         $argc = func_num_args();
-
+        $params = array();
+        
         if (isset($args[0])) {
             if (is_string($args[0])) {
                 $this->apiKey = $args[0];


### PR DESCRIPTION
When call MobizonApi('api_key', 'api_domain'):
Warning: array_intersect_key(): Argument #1 is not an array in /vendor/mobizon/mobizon-php/src/MobizonApi.php on line 144
Warning: Invalid argument supplied for foreach() in /vendor/mobizon/mobizon-php/src/MobizonApi.php on line 145